### PR TITLE
Fix capture stack trace in iOS17.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.97",
       "license": "MIT",
       "dependencies": {
-        "callsites": "^4.0.0",
         "commander": "^8.3.0",
         "html2canvas": "^1.4.1",
         "js-cookie": "^3.0.1",
@@ -3429,17 +3428,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/callsites": {
-      "version": "4.0.0",
-      "resolved": "https://mirrors.tencent.com/npm/callsites/-/callsites-4.0.0.tgz",
-      "integrity": "sha512-y3jRROutgpKdz5vzEhWM34TidDU8vkJppF8dszITeb1PQmSqV3DTxyV8G/lyO/DNvtE1YTedehmw9MPZsCBHxQ==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/camelcase": {
@@ -9595,11 +9583,6 @@
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
       }
-    },
-    "callsites": {
-      "version": "4.0.0",
-      "resolved": "https://mirrors.tencent.com/npm/callsites/-/callsites-4.0.0.tgz",
-      "integrity": "sha512-y3jRROutgpKdz5vzEhWM34TidDU8vkJppF8dszITeb1PQmSqV3DTxyV8G/lyO/DNvtE1YTedehmw9MPZsCBHxQ=="
     },
     "camelcase": {
       "version": "5.3.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "vue-template-compiler": "^2.6.14"
   },
   "dependencies": {
-    "callsites": "^4.0.0",
     "commander": "^8.3.0",
     "html2canvas": "^1.4.1",
     "js-cookie": "^3.0.1",

--- a/src/sdk/common/utils.js
+++ b/src/sdk/common/utils.js
@@ -231,3 +231,13 @@ export function requestSource(url, type, onload, onerror) {
   xhr.setRequestHeader('Accept', accept);
   xhr.send();
 }
+
+export function getCallSites() {
+	const tmp = Error.prepareStackTrace;
+
+	Error.prepareStackTrace = (_, stack) => typeof stack === 'string' ? stack.split('\n') : stack;
+	const stack = new Error().stack.slice(1);
+
+	Error.prepareStackTrace = tmp;
+	return stack;
+}

--- a/src/sdk/domain/runtime.js
+++ b/src/sdk/domain/runtime.js
@@ -1,9 +1,8 @@
 import { objectFormat, objectRelease, objectGroupRelease, getObjectById, getObjectProperties, exceptionFormat, callOnObject } from '../common/remote-obj';
-import { formatErrorStack, getEvaluateResult, getPromiseState } from '../common/utils';
+import { formatErrorStack, getEvaluateResult, getPromiseState, getCallSites } from '../common/utils';
 import { Event } from './protocol';
 import BaseDomain from './domain';
 import Debugger from './debugger';
-import callsites from 'callsites';
 import JDB from '../common/jdb';
 
 const oriEval = window.eval;
@@ -64,7 +63,7 @@ export default class Runtime extends BaseDomain {
     } else if (Error.captureStackTrace) {
       // Safari不支持captureStackTrace，这里判断下
       let consoleIdx = -1; // 记录hook的console位置，忽略这部分调用栈
-      callFrames = callsites().map((val, idx) => {
+      callFrames = getCallSites().map((val, idx) => {
         const url = val.getFileName();
         const funcName = val.getFunctionName() || '(anonymous)';
         if (funcName.includes('window.console.<computed>')) {


### PR DESCRIPTION
## Background

Due to the support of `Error.captureStackTrace` on iOS17.2, but the type of `Error.stack` in Safari is `string`, the processing of generating stack information is out of function on iOS17.2.

## Measure

Specifically handle the stack string generated by Safari to fix the generate stack information function.